### PR TITLE
HildonLiveSearch improvement

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -207,27 +207,32 @@ set_current_view (view *v)
   if (v->id == MAIN_VIEW)
     {
       enable_refresh (false);
+      enable_search (false);
       prevent_updating ();
     }
   else if (v->id == UNINSTALL_APPLICATIONS_VIEW)
     {
       enable_refresh (false);
+      enable_search (true);
       allow_updating ();
     }
   else if (v->id == INSTALL_SECTION_VIEW
            || v->id == SEARCH_RESULTS_VIEW)
     {
       enable_refresh (true);
+      enable_search (true);
       allow_updating ();
     }
   else if (v->id == INSTALL_APPLICATIONS_VIEW)
     {
       enable_refresh (true);
+      enable_search (true);
       allow_updating ();
     }
   else if (v->id == UPGRADE_APPLICATIONS_VIEW)
     {
       enable_refresh (true);
+      enable_search (true);
       allow_updating ();
     }
 

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -33,6 +33,7 @@
 #include "log.h"
 #include "settings.h"
 #include "repo.h"
+#include "search.h"
 #include "apt-worker-client.h"
 #include "user_files.h"
 
@@ -56,6 +57,7 @@ add_item (HildonAppMenu *menu, const gchar *label, void (*func)())
 static GtkWidget *settings_menu_item = NULL;
 static GtkWidget *install_from_file_menu_item = NULL;
 static GtkWidget *refresh_menu_item = NULL;
+static GtkWidget *search_menu_item = NULL;
 
 void
 set_settings_menu_visible (bool flag)
@@ -130,7 +132,11 @@ create_menu ()
     add_item (main,
 	      _("ai_me_settings"),
 	      show_settings_dialog_flow);
-
+  /* Search */
+  search_menu_item =
+    add_item(main,
+           _("ai_me_search"),
+           show_search_dialog_flow);
   gtk_widget_show_all (GTK_WIDGET (main));
 
   /* Hide restore_packages menu item when there is no backup */
@@ -150,7 +156,12 @@ enable_refresh (bool flag)
   if (refresh_menu_item)
     g_object_set (G_OBJECT (refresh_menu_item), "visible", flag, NULL);
 }
-
+void
+enable_search (bool flag)
+{
+  if(search_menu_item)
+    g_object_set(G_OBJECT (search_menu_item), "visible", flag, NULL);
+}
 #if defined (TAP_AND_HOLD) && defined (MAEMO_CHANGES)
 GtkWidget *
 create_package_menu (const char *op_label)

--- a/src/util.cc
+++ b/src/util.cc
@@ -1864,7 +1864,7 @@ button_press_cb (GtkWidget *treeview, GdkEventButton *event, gpointer data)
 #if HILDON_CHECK_VERSION (2,2,5)
 
 static gboolean
-live_search_look_for_prefix (gchar **tokens, const gchar *prefix)
+live_search_look_for (gchar **tokens, const gchar *prefix)
 {
   gchar *needle = NULL;
   gboolean found = false;
@@ -1880,7 +1880,7 @@ live_search_look_for_prefix (gchar **tokens, const gchar *prefix)
   /* Look through the tokens */
   for (i = 0; tokens[i] != NULL; i++)
     {
-      found = g_str_has_prefix (tokens[i], needle);
+      found = (strstr (tokens[i], needle)!=NULL);
 
       /* Don't keep on looking if already found */
       if (found)
@@ -1942,11 +1942,11 @@ live_search_filter_func (GtkTreeModel *model,
     for (i = 0; text_tokens[i] != NULL; i++)
       {
         /* Check package name */
-        retvalue = live_search_look_for_prefix (name_tokens, text_tokens[i]);
+        retvalue = live_search_look_for (name_tokens, text_tokens[i]);
 
         /* Check short description if not found yet */
         if (!retvalue)
-          retvalue = live_search_look_for_prefix (desc_tokens, text_tokens[i]);
+          retvalue = live_search_look_for (desc_tokens, text_tokens[i]);
 
         /* If not found reached this point, don't keep on looking */
         if (!retvalue)


### PR DESCRIPTION
HAM HildonLiveSearch at this moment can only find requested package if a word in a package name/description begins with search string.
This patch allows to search for any occurrence in package name/description